### PR TITLE
MPS plugins migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    open-pull-requests-limit: 20
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 20
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,8 +20,8 @@ fun computeVersion(): Any {
 
 subprojects {
     repositories {
-        // It is useful to have the central maven repo before the Itemis's one as it is more reliable
-        mavenCentral()
+        mavenLocal()
         maven { url = uri("https://artifacts.itemis.cloud/repository/maven-mps/") }
+        mavenCentral()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,8 @@ kotlinx-coroutines = "1.6.4"
 kotlin-logging = "3.0.5"
 ktor = "2.2.4"
 logback = "1.4.6"
-modelix-core = "2.10.5"
+modelix-core = "4.11.5"
+modelix-mps-plugins = "0.5.1"
 
 [libraries]
 auth0-jwt = { group = "com.auth0", name = "java-jwt", version = "3.19.2" }
@@ -50,6 +51,9 @@ modelix-model-client = { group = "org.modelix", name = "model-client", version.r
 modelix-mps-build-tools = { group = "org.modelix.mps", name="build-tools-lib", version = "1.1.0"}
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version = "2.0.6" }
 zt-zip = { group = "org.zeroturnaround", name = "zt-zip", version = "1.14" }
+modelix-mpsPlugins-legacySync = { group = "org.modelix.mps", name = "legacy-sync-plugin", version.ref = "modelix-mps-plugins" }
+modelix-mpsPlugins-generator = { group = "org.modelix.mps", name = "generator-execution-plugin", version.ref = "modelix-mps-plugins" }
+modelix-mpsPlugins-diff = { group = "org.modelix.mps", name = "diff-plugin", version.ref = "modelix-mps-plugins" }
 
 [bundles]
 ktor-client = [
@@ -67,6 +71,11 @@ ktor-server = [
     "ktor-server-auth",
     "ktor-server-status-pages",
     "ktor-server-netty",
+]
+modelix-mpsPlugins-all = [
+    "modelix-mpsPlugins-legacySync",
+    "modelix-mpsPlugins-generator",
+    "modelix-mpsPlugins-diff"
 ]
 
 

--- a/instances-manager/src/main/kotlin/org/modelix/instancesmanager/RedirectedURL.kt
+++ b/instances-manager/src/main/kotlin/org/modelix/instancesmanager/RedirectedURL.kt
@@ -35,6 +35,12 @@ class RedirectedURL(
         url += if (instanceName != null) instanceName?.name else workspaceReference
         url += if (remainingPath.startsWith("/ide/")) {
             ":8887" + remainingPath.substring("/ide".length)
+        } else if (remainingPath.startsWith("/generator/")) {
+            // see https://github.com/modelix/modelix.mps-plugins/blob/bb70966087e2f41c263a7fe4d292e4722d50b9d1/mps-generator-execution-plugin/src/main/kotlin/org/modelix/mps/generator/web/GeneratorExecutionServer.kt#L78
+            ":33335" + remainingPath.substring("/generator".length)
+        } else if (remainingPath.startsWith("/diff/")) {
+            // see https://github.com/modelix/modelix.mps-plugins/blob/bb70966087e2f41c263a7fe4d292e4722d50b9d1/mps-diff-plugin/src/main/kotlin/org/modelix/ui/diff/DiffServer.kt#L82
+            ":33334" + remainingPath.substring("/diff".length)
         } else {
             ":33333$remainingPath"
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,29 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        maven { url = uri("https://artifacts.itemis.cloud/repository/maven-mps/") }
+        mavenCentral()
+    }
+    dependencyResolutionManagement {
+        repositories {
+            mavenLocal()
+            gradlePluginPortal()
+            maven { url = uri("https://artifacts.itemis.cloud/repository/maven-mps/") }
+            mavenCentral()
+        }
+        versionCatalogs {
+            create("coreLibs") {
+                val modelixCoreVersion = file("gradle/libs.versions.toml").readLines()
+                    .first { it.startsWith("modelix-core = ") }
+                    .substringAfter('"')
+                    .substringBefore('"')
+                from("org.modelix:core-version-catalog:$modelixCoreVersion")
+            }
+        }
+    }
+}
+
 rootProject.name = "modelix.workspaces"
 
 include("gitui")

--- a/workspace-client/Dockerfile
+++ b/workspace-client/Dockerfile
@@ -1,5 +1,55 @@
-ARG MODELIX_MPS_COMPONENTS_VERSION
-FROM modelix/modelix-projector:$MODELIX_MPS_COMPONENTS_VERSION
+ARG MPS_VERSION
+# If the version of modelix/projector-mps is missing, run docker-build-projector-mps.sh to build and publish that image
+FROM modelix/projector-mps:$MPS_VERSION AS with-zip
+USER root
+RUN apt-get update  \
+    && apt-get install unzip zip wget -y  \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/cache/apt
+
+FROM with-zip AS patch-branding
+
+COPY helper/patch-branding.sh /
+RUN /patch-branding.sh
+
+FROM with-zip
+
+COPY --from=patch-branding /branding.zip /projector/ide/lib/branding.jar
+
+RUN echo "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5071" >> /projector/ide/bin/mps64.vmoptions \
+    && sed -i.bak '/-Xmx/d' /projector/ide/bin/mps64.vmoptions \
+    && echo "-XX:MaxRAMPercentage=85" >> /projector/ide/bin/mps64.vmoptions \
+    && mkdir -p /mps-plugins \
+    && mkdir -p /mps-languages \
+    && chown -R projector-user:projector-user /home/projector-user \
+    && chown -R projector-user:projector-user /mps-plugins \
+    && chown -R projector-user:projector-user /mps-languages \
+    && chown -R projector-user:projector-user /projector/ide/
+
+# An "End User Agreement" dialog prevents the startup if the vendor name is 'JetBrains'
+# See
+# - https://github.com/JetBrains/intellij-community/blob/777669cc01eb14e6fcf2ed3ba11d2c1d3832d6e2/platform/platform-impl/src/com/intellij/idea/eua.kt#L19-L20
+# - https://github.com/JetBrains/MPS/blob/418307944be761dd1e62af65881c8eade086386f/plugins/mps-build/solutions/mpsBuild/source_gen/jetbrains/mps/ide/build/mps.sh#L224
+# - https://github.com/JetBrains/MPS/blob/418307944be761dd1e62af65881c8eade086386f/plugins/mps-build/solutions/mpsBuild/source_gen/jetbrains/mps/ide/build/mps.sh#L57
+#
+# This way of setting the vendor name is only available in newer MPS versions.
+# For older versions the patch-branding.sh script is still required.
+RUN sed -i.bak "s/IDEA_VENDOR_NAME='JetBrains'/IDEA_VENDOR_NAME='Modelix'/g" /projector/ide/bin/mps.sh
+
+USER projector-user
+
+COPY --chown=projector-user:projector-user helper/projector-user-home /home/projector-user
+
+# rename config directory to match the correct MPS version
+RUN mv "/home/projector-user/.config/JetBrains/MPSxxxx.x" "/home/projector-user/.config/JetBrains/MPS$(grep "mpsBootstrapCore.version=" /projector/ide/build.properties|cut -d'=' -f2)"
+
+# changing the vendor name (see above) also changes the location of the config dir
+RUN ln -s /home/projector-user/.config/JetBrains /home/projector-user/.config/Modelix
+
+COPY --chown=projector-user:projector-user helper/log.xml /projector/ide/bin/log.xml
+
+COPY helper/install-plugins.sh /
+RUN /install-plugins.sh /projector/ide/plugins/
 
 USER root
 
@@ -7,6 +57,31 @@ COPY build/libs/workspace-client-latest-all.jar /home/projector-user/workspace-c
 COPY download-workspace-and-start-projector.sh /
 
 RUN chown -R projector-user:projector-user /home/projector-user/
+
+#RUN rm -rf /projector/ide/plugins/org.modelix.*
+#RUN rm -rf /projector/ide/plugins/com.mbeddr.*
+#RUN rm -rf /projector/ide/plugins/com.dslfoundry.*
+#RUN rm -rf /projector/ide/plugins/de.itemis.*
+#RUN rm -rf /projector/ide/plugins/de-itemis-*
+#RUN rm -rf /projector/ide/plugins/de.q60.*
+#RUN rm -rf /projector/ide/plugins/de.slisson.*
+#RUN rm -rf /projector/ide/plugins/mps-math-editor
+#RUN rm -rf /projector/ide/plugins/mps-multiline
+#RUN rm -rf /projector/ide/plugins/mps-richtext
+#RUN rm -rf /projector/ide/plugins/mps-tables
+
+# <editor-fold desc="yourkit">
+# https://www.yourkit.com/docs/java-profiler/2023.9/help/docker_direct.jsp
+
+#RUN wget https://www.yourkit.com/download/docker/YourKit-JavaProfiler-2023.9-docker.zip -P /tmp/ && \
+#  unzip /tmp/YourKit-JavaProfiler-2023.9-docker.zip -d /usr/local && \
+#  rm /tmp/YourKit-JavaProfiler-2023.9-docker.zip
+#RUN echo "-agentpath:/usr/local/YourKit-JavaProfiler-2023.9/bin/linux-x86-64/libyjpagent.so=port=10001,listen=all" >> /projector/ide/bin/mps64.vmoptions
+
+# </editor-fold>
+
+COPY --chown=projector-user:projector-user build/mps-plugins /projector/ide/plugins
+
 USER projector-user
 
 WORKDIR /home/projector-user/

--- a/workspace-client/build.gradle.kts
+++ b/workspace-client/build.gradle.kts
@@ -18,6 +18,20 @@ tasks.withType<ShadowJar> {
     archiveVersion.set("latest")
 }
 
+// <editor-fold desc="IDEA plugins">
+val modelixIdeaPlugins: Configuration by configurations.creating
+dependencies {
+    modelixIdeaPlugins(libs.bundles.modelix.mpsPlugins.all)
+}
+val copyMpsPlugins by tasks.registering(Sync::class) {
+    from(modelixIdeaPlugins.resolve().map { zipTree(it) })
+    into(project.layout.buildDirectory.dir("mps-plugins"))
+}
+tasks.assemble {
+    dependsOn(copyMpsPlugins)
+}
+// </editor-fold>
+
 dependencies {
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.netty)

--- a/workspace-client/docker-build-local-and-publish-on-ci.sh
+++ b/workspace-client/docker-build-local-and-publish-on-ci.sh
@@ -15,13 +15,13 @@ MODELIX_WORKSPACES_VERSION="$(cat ../workspaces-version.txt)"
 
 # Create a workspace-client image for each MPS version
 for MPS_MAJOR_VERSION in $(getProperty mpsMajorVersions | tr "," "\n"); do
-  MODELIX_MPS_COMPONENTS_VERSION=$(getProperty modelixMpsComponentsVersion"$MPS_MAJOR_VERSION")
+  MODELIX_MPS_COMPONENTS_VERSION=$(getProperty mpsVersion"$MPS_MAJOR_VERSION")
   TAG=${MODELIX_WORKSPACES_VERSION}-${MPS_MAJOR_VERSION}
   if [ "${CI}" = "true" ]; then
     docker buildx build \
       --platform linux/amd64 \
       --push \
-      --build-arg MODELIX_MPS_COMPONENTS_VERSION=${MODELIX_MPS_COMPONENTS_VERSION} \
+      --build-arg MPS_VERSION=${MPS_MAJOR_VERSION} \
       -t "modelix/modelix-workspace-client:${TAG}" .
   # Only linux/amd64 (especially not linux/arm64)  is not supported
   # Therefore build image with platform linux/amd64
@@ -29,11 +29,11 @@ for MPS_MAJOR_VERSION in $(getProperty mpsMajorVersions | tr "," "\n"); do
   elif [ "$(uname -m)" != "x86_64" ]; then
         docker buildx build \
           --platform linux/amd64 \
-          --build-arg MODELIX_MPS_COMPONENTS_VERSION=${MODELIX_MPS_COMPONENTS_VERSION} \
+          --build-arg MPS_VERSION=${MPS_MAJOR_VERSION} \
           -t "modelix/modelix-workspace-client:${TAG}" .
   else
     docker build \
-      --build-arg MODELIX_MPS_COMPONENTS_VERSION=${MODELIX_MPS_COMPONENTS_VERSION}\
+      --build-arg MPS_VERSION=${MPS_MAJOR_VERSION} \
       -t "modelix/modelix-workspace-client:${TAG}" .
   fi
 done

--- a/workspace-client/helper/install-plugins.sh
+++ b/workspace-client/helper/install-plugins.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Only used in the modelix/modelix-mps docker image as an easy way to build custom images with additional plugins.
+# Finds and copies all MPS plugins from SOURCE_FOLDER to TARGET_FOLDER. Zip files containing plugins are extracted.
+
+TARGET_FOLDER="${1:-/usr/modelix-ui/mps/plugins/}"
+SOURCE_FOLDER="${2:-/mps-plugins/}"
+DELETE_INPUT_FOLDER="${3:-1}"
+
+#SOURCE_FOLDER=../test_input
+#TARGET_FOLDER=../test_output/
+#rm -rf $SOURCE_FOLDER
+#rm -rf $TARGET_FOLDER
+#mkdir $SOURCE_FOLDER
+#mkdir $TARGET_FOLDER
+#cp -R ./build $SOURCE_FOLDER
+
+find $SOURCE_FOLDER -name '*.zip' |
+while IFS= read -r line; do
+  ZIP_OUTPUT_DIR="$line-unzip"
+  unzip -d $ZIP_OUTPUT_DIR $line
+done
+
+find $SOURCE_FOLDER -path '**/META-INF/plugin.xml' |
+while IFS= read -r line; do
+  PLUGIN_DIR="$(dirname "$(dirname $line)")"
+  mv $PLUGIN_DIR $TARGET_FOLDER
+  echo "Installed plugin from $PLUGIN_DIR"
+done
+
+if [ $DELETE_INPUT_FOLDER -eq "1" ]; then
+  rm -rf "${SOURCE_FOLDER:?}"/*
+fi

--- a/workspace-client/helper/log.xml
+++ b/workspace-client/helper/log.xml
@@ -1,0 +1,160 @@
+<?xml version='1.0' encoding='ISO-8859-1' ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<!--
+IntelliJ Platform log all STDOUT and STDERR output to idea.log file by default.
+See com.intellij.idea.StartupUtil#setupLogger system property 'intellij.log.stdout'.
+
+Two main appenders are FILE and DIALOG:
+FILE is responsible for logging to the idea.log file.
+DIALOG is responsible for showing ERROR level (at least) events in UI (events are ignored in command line mode).
+
+MPS additionally logs VCS events to mpsvcs.log file: categories are used for that.
+
+Appenders CONSOLE-* can be used to debug purposes to get application output to the console.
+Note that adding this appenders to root appender will result in duplication of entries in idea.log file.
+
+CONTINUOUS_FILE appender can also be used for debugging.
+It does not interfere with console output and idea.log, but uses separate continuous.log file.
+
+All file appenders use $LOG_DIR$ folder for store files.
+In MPS sources some run configurations override this path by setting 'idea.log.path' variable to '$PROJECT_DIR$/log'.
+-->
+
+<!-- Parameter 'follow = true' in appenders with class 'ConsoleAppender' is required for proper test light execution -->
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <!-- Output events with level at least WARN to console. See org.apache.log4j.Level.WARN -->
+  <appender name="CONSOLE-WARN" class="org.apache.log4j.ConsoleAppender">
+    <param name="follow" value="true"/>
+    <param name="target" value="System.err"/>
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="[%7r] %6p - %30.60c - %m \n"/>
+    </layout>
+    <filter class="org.apache.log4j.varia.LevelRangeFilter">
+      <param name="LevelMin" value="WARN"/>
+    </filter>
+  </appender>
+
+  <!-- Output only events with level DEBUG to console. See org.apache.log4j.Level.DEBUG -->
+  <appender name="CONSOLE-DEBUG" class="org.apache.log4j.ConsoleAppender">
+    <param name="follow" value="true"/>
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="[%7r] %6p - %30.60c - %m \n"/>
+    </layout>
+    <filter class="org.apache.log4j.varia.LevelRangeFilter">
+      <param name="LevelMin" value="DEBUG"/>
+      <param name="LevelMax" value="DEBUG"/>
+    </filter>
+  </appender>
+
+  <!-- Output only events with level TRACE to console. See org.apache.log4j.Level.TRACE -->
+  <appender name="CONSOLE-TRACE" class="org.apache.log4j.ConsoleAppender">
+    <param name="follow" value="true"/>
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="[%7r] %6p - %30.60c - %m \n"/>
+    </layout>
+    <filter class="org.apache.log4j.varia.LevelRangeFilter">
+      <param name="LevelMin" value="TRACE"/>
+      <param name="LevelMax" value="TRACE"/>
+    </filter>
+  </appender>
+
+  <!-- Output all events to console -->
+  <appender name="CONSOLE-ALL" class="org.apache.log4j.ConsoleAppender">
+    <param name="follow" value="true"/>
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="[%7r] %6p - %30.60c - %m \n"/>
+    </layout>
+  </appender>
+
+  <!-- Show events with level at least ERROR in UI -->
+  <appender name="DIALOG" class="com.intellij.diagnostic.DialogAppender">
+    <!-- DialogAppender does nothing with event which level is less then ERROR so there is no need to pass them to DialogAppender -->
+    <filter class="org.apache.log4j.varia.LevelRangeFilter">
+      <param name="LevelMin" value="ERROR"/>
+    </filter>
+  </appender>
+
+  <!-- Log all events to idea.log file. Maintain number of logs and file sizes. -->
+  <appender name="FILE" class="org.apache.log4j.RollingFileAppender">
+    <param name="MaxFileSize" value="1Mb"/>
+    <param name="MaxBackupIndex" value="12"/>
+    <param name="File" value="$LOG_DIR$/idea.log"/>
+    <param name="Encoding" value="UTF-8"/>
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d [%7r] %6p - %30.60c - %m \n"/>
+    </layout>
+  </appender>
+
+  <!-- Log all events to continuous.log file. Note that file is overridden on each application start -->
+  <appender name="CONTINUOUS_FILE" class="org.apache.log4j.FileAppender">
+    <param name="File" value="$LOG_DIR$/continuous.log"/>
+    <param name="Encoding" value="UTF-8"/>
+    <param name="append" value="false"/>
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d [%7r] %6p - %30.60c - %m \n"/>
+    </layout>
+  </appender>
+
+  <!-- Log events to mpsvcs.log file -->
+  <appender name="FILE-VCS" class="org.apache.log4j.RollingFileAppender">
+    <param name="MaxFileSize" value="2Mb"/>
+    <param name="MaxBackupIndex" value="5"/>
+    <param name="file" value="$LOG_DIR$/mpsvcs.log"/>
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d [%7r] %6p - %30.60c - %m \n"/>
+    </layout>
+  </appender>
+
+  <!-- Additionally log MPS specific vcs events to mpsvcs.log -->
+  <category name="jetbrains.mps.vcs">
+    <priority value="INFO"/>
+    <appender-ref ref="FILE-VCS"/>
+  </category>
+
+  <!-- Additionally log IntelliJ Platform vcs events to mpsvcs.log -->
+  <category name="com.intellij.openapi.vcs">
+    <priority value="INFO"/>
+    <appender-ref ref="FILE-VCS"/>
+  </category> 
+  
+  <category name="de.q60" additivity="true">
+    <priority value="DEBUG"/>
+    <appender-ref ref="CONSOLE-ALL"/>
+  </category>
+
+  <category name="org.modelix" additivity="true">
+    <priority value="DEBUG"/>
+    <appender-ref ref="CONSOLE-ALL"/>
+  </category>   
+
+  <!--
+  Template category for debugging:
+  Set required logger prefix and choose appropriate appender.
+  Set required priority: TRACE, DEBUG, INFO, WARN, ERROR etc (See org.apache.log4j.Level).
+  Choose required debug appender or add your own.
+  -->
+  <!--
+  <category name="logger.prefix">
+    <priority value="TRACE"/>
+    <appender-ref ref="CONSOLE-WARN"/>
+    <appender-ref ref="CONSOLE-DEBUG"/>
+    <appender-ref ref="CONSOLE-TRACE"/>
+    <appender-ref ref="CONSOLE-ALL"/>
+    <appender-ref ref="CONTINUOUS_FILE" />
+  </category>
+  -->
+
+  <root>
+    <priority value="INFO"/>
+    <appender-ref ref="DIALOG"/>
+    <appender-ref ref="FILE"/>
+    <!-- For quick debug  -->
+    <!--<appender-ref ref="CONSOLE-ALL" />-->
+    <appender-ref ref="CONSOLE-WARN"/>
+    <!--<appender-ref ref="CONSOLE-DEBUG"/>-->
+    <!--<appender-ref ref="CONSOLE-TRACE"/>-->
+    <!--<appender-ref ref="CONTINUOUS_FILE" />-->
+  </root>
+</log4j:configuration>

--- a/workspace-client/helper/modelix-version.sh
+++ b/workspace-client/helper/modelix-version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+MPS_VERSION=$( ./helper/mps-version.sh )
+VERSION_FILE="../modelix.version"
+
+if [ -f "${VERSION_FILE}" ]; then
+    MODELIX_VERSION=$(cat ${VERSION_FILE})
+else
+    echo "Unable to find modelix.version in root - will generate SNAPSHOT version"
+    MODELIX_VERSION="${MPS_VERSION}-$(date +"%Y%m%d%H%M")-SNAPSHOT"
+    echo "$MODELIX_VERSION" > ${VERSION_FILE}
+fi
+
+echo "${MODELIX_VERSION}"

--- a/workspace-client/helper/mps-version.sh
+++ b/workspace-client/helper/mps-version.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# assumes to be executed in the docker folder
+
+set -e
+
+MPS_VERSION=$(cat "../gradle/mps.versions.toml" | grep "mpsbase =" | cut -d " " -f3 | tr -d "\"")
+
+
+if [ -z "${MPS_VERSION}" ]; then
+    echo "Error: Unable to read MPS version from gradle toml"
+    exit 1
+fi
+
+echo "${MPS_VERSION}"

--- a/workspace-client/helper/patch-branding.sh
+++ b/workspace-client/helper/patch-branding.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# patch branding.jar to not show EULA and data sharing agreement at startup
+
+unzip -d /branding /projector/ide/lib/branding.jar
+(
+  cd /branding
+  sed -i.bak -E "s/JetBrains s.r.o./Modelix/" idea/IdeaApplicationInfo.xml
+  rm idea/IdeaApplicationInfo.xml.bak
+  zip -r /branding.zip ./*
+)

--- a/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/disabled_plugins.txt
+++ b/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/disabled_plugins.txt
@@ -1,0 +1,1 @@
+jetbrains.mps.ide.migration.workbench

--- a/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/idea.properties
+++ b/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/idea.properties
@@ -1,0 +1,1 @@
+idea.fatal.error.notification=disabled

--- a/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/options/AdditionalLibrariesManager.xml
+++ b/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/options/AdditionalLibrariesManager.xml
@@ -1,0 +1,32 @@
+<application>
+    <component name="AdditionalLibrariesManager">
+        <option name="libraries">
+            <map>
+                <entry key="packaged-languages-user">
+                    <value>
+                        <Library>
+                            <option name="name" value="packaged-languages-user" />
+                            <option name="path" value="$USER_HOME$/mps-languages" />
+                        </Library>
+                    </value>
+                </entry>
+                <entry key="packaged-languages">
+                    <value>
+                        <Library>
+                            <option name="name" value="packaged-languages" />
+                            <option name="path" value="/mps-languages" />
+                        </Library>
+                    </value>
+                </entry>
+                <entry key="workspace">
+                    <value>
+                        <Library>
+                            <option name="name" value="workspace" />
+                            <option name="path" value="$USER_HOME$/workspace.zip/" />
+                        </Library>
+                    </value>
+                </entry>
+            </map>
+        </option>
+    </component>
+</application>

--- a/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/options/ide.general.xml
+++ b/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/options/ide.general.xml
@@ -1,0 +1,12 @@
+<application>
+    <component name="GeneralSettings">
+        <option name="showTipsOnStartup" value="false" />
+    </component>
+    <component name="StatusBar">
+        <option name="widgets">
+            <map>
+                <entry key="Memory" value="true" />
+            </map>
+        </option>
+    </component>
+</application>

--- a/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/options/notifications.xml
+++ b/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/options/notifications.xml
@@ -1,0 +1,6 @@
+<application>
+    <component name="NotificationConfiguration">
+        <notification groupId="IDE and Plugin Updates" displayType="NONE" shouldLog="false" />
+        <notification groupId="Plugins updates" displayType="NONE" shouldLog="false" />
+    </component>
+</application>

--- a/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/options/path.macros.xml
+++ b/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/options/path.macros.xml
@@ -1,0 +1,5 @@
+<application>
+    <component name="PathMacrosImpl">
+        <macro name="MODELIX_WORKSPACE" value="/home/projector-user/workspace.zip" />
+    </component>
+</application>

--- a/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/options/recentProjects.xml
+++ b/workspace-client/helper/projector-user-home/.config/JetBrains/MPSxxxx.x/options/recentProjects.xml
@@ -1,0 +1,14 @@
+<application>
+    <component name="RecentProjectsManager">
+        <option name="additionalInfo">
+            <map>
+                <entry key="$USER_HOME$/default-mps-project">
+                    <value>
+                        <RecentProjectMetaInfo frameTitle="default-mps-project" opened="true">
+                        </RecentProjectMetaInfo>
+                    </value>
+                </entry>
+            </map>
+        </option>
+    </component>
+</application>

--- a/workspace-client/helper/projector-user-home/default-mps-project/.mps/migration.xml
+++ b/workspace-client/helper/projector-user-home/default-mps-project/.mps/migration.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MigrationProperties">
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
+  </component>
+</project>

--- a/workspace-client/helper/projector-user-home/default-mps-project/.mps/modules.xml
+++ b/workspace-client/helper/projector-user-home/default-mps-project/.mps/modules.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MPSProject">
+    <projectModules />
+  </component>
+</project>

--- a/workspace-job/Dockerfile
+++ b/workspace-job/Dockerfile
@@ -8,7 +8,7 @@ COPY build/install/workspace-job /workspace-job/
 ARG MPS_MAJOR_VERSION
 COPY build/mps$MPS_MAJOR_VERSION/artifacts/mps /mps
 
-COPY build/mps$MPS_MAJOR_VERSION/artifacts/de.itemis.mps.extensions /languages/mps-extensions
-COPY build/mps$MPS_MAJOR_VERSION/artifacts/org.modelix /languages/modelix/plugins
+#COPY build/mps$MPS_MAJOR_VERSION/artifacts/de.itemis.mps.extensions /languages/mps-extensions
+#COPY build/mps$MPS_MAJOR_VERSION/artifacts/org.modelix /languages/modelix/plugins
 
 CMD ["/workspace-job/bin/workspace-job", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5071", "-Dmps.home=/mps", "-XX:MaxRAMPercentage=75"]

--- a/workspace-manager/src/main/kotlin/org/modelix/workspace/manager/WorkspaceManagerModule.kt
+++ b/workspace-manager/src/main/kotlin/org/modelix/workspace/manager/WorkspaceManagerModule.kt
@@ -120,14 +120,15 @@ fun Application.workspaceManagerModule() {
                                                     text((workspace?.name ?: "<no name>") + " ($workspaceId)")
                                                 }
                                             }
-                                            td {
-                                                if (canRead) {
-                                                    a {
-                                                        href = "../${workspaceInstanceUrl(workspaceAndHash)}/project"
-                                                        text("Open Web Interface")
-                                                    }
-                                                }
-                                            }
+                                            // Shadow models based UI was removed
+//                                            td {
+//                                                if (canRead) {
+//                                                    a {
+//                                                        href = "../${workspaceInstanceUrl(workspaceAndHash)}/project"
+//                                                        text("Open Web Interface")
+//                                                    }
+//                                                }
+//                                            }
                                             td {
                                                 if (canRead) {
                                                     a {
@@ -332,9 +333,10 @@ fun Application.workspaceManagerModule() {
                                 div("menuItem") {
                                     a("../${workspaceAndHash.hash().hash}/buildlog") { +"Build Log" }
                                 }
-                                div("menuItem") {
-                                    a("../../${workspaceInstanceUrl(workspaceAndHash)}/project") { +"Open Web Interface" }
-                                }
+                                // Shadow models based UI was removed
+//                                div("menuItem") {
+//                                    a("../../${workspaceInstanceUrl(workspaceAndHash)}/project") { +"Open Web Interface" }
+//                                }
                                 div("menuItem") {
                                     a("../../${workspaceInstanceUrl(workspaceAndHash)}/ide/") { +"Open MPS" }
                                 }


### PR DESCRIPTION
This uses the MPS plugins that were migrated to MPS 2023.2. The "Open Web Interface" button is now removed, because the support for it was dropped. We will re-implement this functionality with a different approach in a future release.