### PR TITLE
chore(deps): Setup renovate for Docker images

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm ci
       - name: Dry-run release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # We need to convince semantic-release to not pick up some
         # configuration from the CI environment by removing the variable that
         # is used for CI detection.

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,29 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:best-practices"
+  ],
+  enabledManagers: ["dockerfile", "custom.regex"],
+  customManagers: [
+    {
+      // Custom manager for Docker image version in version.properties
+      customType: "regex",
+      fileMatch: ["^version.properties$"],
+      matchStrings: [
+        "javaImage(?<javaVersion>.*?)=(?<packageName>.*?):(?<currentValue>.*?)@(?<currentDigest>sha256:[a-f0-9]+)\\s"
+      ],
+      depTypeTemplate: "javaImageForMps",
+      datasourceTemplate: "docker",
+      versioningTemplate: "docker"
+    }
+  ],
+  packageRules: [
+    {
+      // Disable updates to major versions of Java containers running MPS.
+      // MPS may rely on old Java version features.
+      matchDepTypes: ["javaImageForMps"],
+      matchUpdateTypes: ["major"],
+      enabled: false
+    }
+  ]
+}


### PR DESCRIPTION
[Here](https://github.com/odzhychko/modelix.workspaces/issues/14) you can see the dependency dashboard produced by this configuration.
[Here](https://github.com/odzhychko/modelix.workspaces/pull/12) you can see a sample PR.

---

To activate Renovate, we need to activate [the Renovate App](https://github.com/apps/renovate) for this repository.

An alternative would be to run Renovate periodically as an action.
But I decided to use the App because it is free and more responsive than a periodical GitHub Actions workflow.