### PR TITLE
fix(workspace-manager): do not generate job names with trailing hyphens

### DIFF
--- a/workspace-manager/src/main/kotlin/org/modelix/workspace/manager/WorkspaceJobQueue.kt
+++ b/workspace-manager/src/main/kotlin/org/modelix/workspace/manager/WorkspaceJobQueue.kt
@@ -277,7 +277,9 @@ class WorkspaceJobQueue(val tokenGenerator: (Workspace) -> String) {
             var jobName = JOB_PREFIX + cleanName
             val charsToRemove = jobName.length - (63 - 16)
             if (charsToRemove > 0) jobName = jobName.substring(0, jobName.length - charsToRemove)
-            return jobName
+            // Delete forbidden trailing hyphens ("-") that could be part of `HashUtil.sha256`.
+            // HashUtil.sha256 uses Base64 for URL which might contain "-".
+            return jobName.trimEnd('-')
         }
     }
 }


### PR DESCRIPTION
See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/

An alternative would be to only specify `workspace.id + "-" + workspace.hash().hash.take(5) + "-"` as a prefix and let Kubernetes generate an ID (with `generateName`).